### PR TITLE
instruction: Add no-alloc helper for instruction data

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can run the convenience script in this repo to download the compiler to
 1. Add this package to your project:
 
 ```console
-zig fetch --save https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.14.0.tar.gz
+zig fetch --save https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.14.1.tar.gz
 ```
 
 2. (Optional) if you want to generate a keypair during building, you'll also

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "solana-program-sdk",
-    .version = "0.14.0",
+    .version = "0.14.1",
     .minimum_zig_version = "0.13.0",
 
     // This field is optional.


### PR DESCRIPTION
#### Problem

Constructing instruction data requires using a serialization library
such as bincode or borsh, but it's much simpler to create an instance of
the instruction and just reinterpret those bytes (assuming the type is a
properly packed struct).

#### Summary of changes

Add a helper for creating a type used for instruction data.