### PR TITLE
version: Bump to 0.14.2 for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can run the convenience script in this repo to download the compiler to
 1. Add this package to your project:
 
 ```console
-zig fetch --save https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.14.1.tar.gz
+zig fetch --save https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.14.2.tar.gz
 ```
 
 2. (Optional) if you want to generate a keypair during building, you'll also

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "solana-program-sdk",
-    .version = "0.14.1",
+    .version = "0.14.2",
     .minimum_zig_version = "0.13.0",
 
     // This field is optional.


### PR DESCRIPTION
#### Problem

#5 fixed the instruction data helper, but it's not released.

#### Summary of changes

Bump to 0.14.2 for release.