### PR TITLE
entrypoint: Optimize to reduce by a few CUs

### DIFF
--- a/src/account.zig
+++ b/src/account.zig
@@ -52,6 +52,10 @@ pub const Account = struct {
 
     ptr: *Account.Data,
 
+    pub fn fromDataPtr(ptr: *Account.Data) Account {
+        return Account { .ptr = ptr };
+    }
+
     pub fn id(self: Account) PublicKey {
         return self.ptr.id;
     }

--- a/src/context.zig
+++ b/src/context.zig
@@ -6,7 +6,7 @@ const allocator = @import("allocator.zig").allocator;
 const PublicKey = @import("public_key.zig").PublicKey;
 
 pub const Context = struct {
-    num_accounts: usize,
+    num_accounts: u64,
     accounts: [64]Account,
     data: []const u8,
     program_id: *align(1) PublicKey,
@@ -14,36 +14,34 @@ pub const Context = struct {
     pub fn load(input: [*]u8) !Context {
         var ptr: [*]u8 = input;
 
-        const num_accounts = std.mem.bytesToValue(usize, ptr[0..@sizeOf(usize)]);
-        ptr += @sizeOf(usize);
+        const num_accounts: *u64 = @ptrCast(@alignCast(ptr));
+        ptr += @sizeOf(u64);
 
         var i: usize = 0;
         var accounts: [64]Account = undefined;
-        while (i < num_accounts) {
-            const data: *align(1) Account.Data = @ptrCast(ptr);
+        while (i < num_accounts.*) {
+            const data: *Account.Data = @ptrCast(@alignCast(ptr));
             if (data.duplicate_index != std.math.maxInt(u8)) {
-                ptr += @sizeOf(usize);
+                ptr += @sizeOf(u64);
                 accounts[i] = accounts[data.duplicate_index];
             } else {
-                ptr += Account.DATA_HEADER;
-                ptr = @as([*]u8, @ptrFromInt(std.mem.alignForward(usize, @intFromPtr(ptr) + data.data_len + ACCOUNT_DATA_PADDING, @alignOf(usize))));
-                ptr += @sizeOf(u64);
-                accounts[i] = .{ .ptr = @as(*Account.Data, @ptrCast(@alignCast(data))) };
+                accounts[i] = Account.fromDataPtr(data);
+                ptr += Account.DATA_HEADER + data.data_len + ACCOUNT_DATA_PADDING + @sizeOf(u64);
+                ptr = @ptrFromInt(std.mem.alignForward(u64, @intFromPtr(ptr), @alignOf(u64)));
             }
             i += 1;
         }
 
-        const data_len = std.math.cast(usize, std.mem.bytesToValue(u64, ptr[0..@sizeOf(u64)])) orelse return error.DataTooLarge;
+        const data_len: *u64 = @ptrCast(@alignCast(ptr));
         ptr += @sizeOf(u64);
 
-        const data = ptr[0..data_len];
-        ptr += data_len;
+        const data = ptr[0..data_len.*];
+        ptr += data_len.*;
 
         const program_id = @as(*align(1) PublicKey, @ptrCast(ptr));
-        ptr += @sizeOf(PublicKey);
 
         return Context{
-            .num_accounts = num_accounts,
+            .num_accounts = num_accounts.*,
             .accounts = accounts,
             .data = data,
             .program_id = program_id,


### PR DESCRIPTION
#### Problem

There's a few inefficiencies in the entrypoint taking up a few unnecessary CUs.

#### Summary of changes

Do some math all together to use fewer CUs during the entrypoint. For the transfer-lamports example in Rosetta, this brings CU usage down from 44 CUs to 38 CUs.