### PR TITLE
Fix account.info(), turn Pubkey back into bytes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 name: Build library and test programs
 
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
 
 env:
   SOLANA_ZIG_VERSION: v1.47.0

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xdc47aff950fd68c0,
     .name = .solana_program_sdk,
-    .version = "0.16.0",
+    .version = "0.16.1",
     .minimum_zig_version = "0.14.0",
 
     // This field is optional.

--- a/program-test/install-build-deps.sh
+++ b/program-test/install-build-deps.sh
@@ -2,9 +2,22 @@
 set -e
 case $(uname -s | cut -c1-7) in
 "Windows" | "MINGW64")
-  choco install openssl --version 3.4.1 --install-arguments="'/DIR=C:\OpenSSL'" -y
-  export OPENSSL_LIB_DIR='C:\OpenSSL\lib\VC\x64\MT'
-  export OPENSSL_INCLUDE_DIR='C:\OpenSSL\include'
+  cat > vcpkg.json <<EOL
+{
+  "dependencies": ["openssl"],
+  "overrides": [
+    {
+      "name": "openssl",
+      "version": "3.4.1"
+    }
+  ],
+  "builtin-baseline": "5ee5eee0d3e9c6098b24d263e9099edcdcef6631"
+}
+EOL
+  vcpkg install --triplet x64-windows-static-md
+  rm vcpkg.json
+  export "OPENSSL_LIB_DIR=$GITHUB_WORKSPACE/vcpkg_installed/x64-windows-static-md/lib"
+  export "OPENSSL_INCLUDE_DIR=$GITHUB_WORKSPACE/vcpkg_installed/x64-windows-static-md/include"
   choco install protoc
   export PROTOC='C:\ProgramData\chocolatey\lib\protoc\tools\bin\protoc.exe'
   ;;

--- a/src/account.zig
+++ b/src/account.zig
@@ -1,12 +1,13 @@
 const std = @import("std");
 const PublicKey = @import("public_key.zig").PublicKey;
+const testing = std.testing;
 
 pub const ACCOUNT_DATA_PADDING = 10 * 1024;
 
 pub const Account = struct {
     pub const DATA_HEADER = 88;
     /// A Solana account sliced from what is provided as inputs to the BPF virtual machine.
-    pub const Data = packed struct {
+    pub const Data = extern struct {
         duplicate_index: u8,
         is_signer: u8,
         is_writable: u8,
@@ -44,16 +45,16 @@ pub const Account = struct {
         data_len: u64,
         data: [*]u8,
         owner_id: *const PublicKey,
-        rent_epoch: u64,
-        is_signer: bool,
-        is_writable: bool,
-        is_executable: bool,
+        unused: u64 = undefined,
+        is_signer: u8,
+        is_writable: u8,
+        is_executable: u8,
     };
 
     ptr: *Account.Data,
 
     pub fn fromDataPtr(ptr: *Account.Data) Account {
-        return Account { .ptr = ptr };
+        return Account{ .ptr = ptr };
     }
 
     pub fn id(self: Account) PublicKey {
@@ -107,7 +108,6 @@ pub const Account = struct {
 
     pub fn info(self: Account) Account.Info {
         const data_ptr = @as([*]u8, @ptrFromInt(@intFromPtr(self.ptr))) + DATA_HEADER;
-        const rent_epoch = @as(*u64, @ptrFromInt(std.mem.alignForward(u64, @intFromPtr(self.ptr) + self.ptr.data_len + ACCOUNT_DATA_PADDING, @alignOf(u64))));
 
         return .{
             .id = &self.ptr.id,
@@ -115,10 +115,30 @@ pub const Account = struct {
             .data_len = self.ptr.data_len,
             .data = data_ptr,
             .owner_id = &self.ptr.owner_id,
-            .rent_epoch = rent_epoch.*,
             .is_signer = self.ptr.is_signer,
             .is_writable = self.ptr.is_writable,
             .is_executable = self.ptr.is_executable,
         };
     }
 };
+
+test "account: create info from account" {
+    var data: Account.Data = .{
+        .duplicate_index = 255,
+        .is_signer = 1,
+        .is_writable = 1,
+        .is_executable = 0,
+        .original_data_len = 10,
+        .id = PublicKey.from(.{1} ** 32),
+        .owner_id = PublicKey.from(.{2} ** 32),
+        .lamports = 1,
+        .data_len = 10,
+    };
+    const account: Account = .{ .ptr = &data };
+    const info = account.info();
+    try testing.expectEqual(info.id, &data.id);
+    try testing.expectEqual(info.is_signer, data.is_signer);
+    try testing.expectEqual(info.is_writable, data.is_writable);
+    try testing.expectEqual(info.lamports, &data.lamports);
+    try testing.expectEqual(info.data, account.data().ptr);
+}


### PR DESCRIPTION
#### Problem

`Account.info()` doesn't work with `PublicKey` as a packed struct because the alignment is incorrect.

#### Summary of changes

Make `PublicKey` back into an array of bytes, remove rent_epoch, and add a test to make sure the `info()` function works.